### PR TITLE
Enable dynamic backend resolution for nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,12 @@ http {
     # Nginx DNS feloldás a dinamikus hostokhoz (pl. java-backend)
     resolver 127.0.0.11 valid=10s;
 
+    # Dinamikusan feloldott upstream definíció. Az "resolve" opció biztosítja,
+    # hogy az Nginx akkor is elinduljon, ha a java-backend konténer még nem él.
+    upstream backend {
+        server java-backend:8082 resolve;
+    }
+
     log_format custom_log '$remote_addr - $remote_user [$time_local] '
                           '"$request" $status $body_bytes_sent '
                           '"$upstream_addr" "$upstream_response_time"';
@@ -29,12 +35,10 @@ http {
 
         # Az útvonal, amit a java-client hív a backend eléréséhez
         location /backend-api/ {
-            set $upstream_backend_host "java-backend";
-            # NEM vágjuk le az /backend-api/ prefixet!
-            # Helyette az /api/ prefixet adjuk hozzá.
-            # Pl.: /backend-api/data -> http://java-backend:8082/api/data
-#             proxy_pass http://$upstream_backend_host:8082/api/; # <-- Módosítás itt: /api/ a végén
-            proxy_pass http://java-backend:8082/api/;
+            # A backend konténer a fenti "backend" upstreamen keresztül érhető el.
+            # A proxy_pass URL-ben szereplő /api/ miatt az /backend-api/ prefix
+            # automatikusan lecserélődik /api/-re.
+            proxy_pass http://backend/api/;
 
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- prevent nginx startup failure when backend isn't present
- use `upstream backend` block with `resolve`
- adjust proxy_pass to new upstream

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68429d53b3ac832c8996fbc067dd6d0c