### PR TITLE
Allow nginx to resolve backend after late start

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,10 @@ http {
     # Nginx DNS feloldás a dinamikus hostokhoz (pl. java-backend)
     resolver 127.0.0.11 valid=10s;
 
+    # A backend kiszolgálót DNS alapon keressük. A "resolver" direktíva miatt
+    # az Nginx újra megkísérli a névfeloldást, így a szolgáltatás későbbi
+    # indítását is kezelni tudjuk.
+
     log_format custom_log '$remote_addr - $remote_user [$time_local] '
                           '"$request" $status $body_bytes_sent '
                           '"$upstream_addr" "$upstream_response_time"';
@@ -29,12 +33,14 @@ http {
 
         # Az útvonal, amit a java-client hív a backend eléréséhez
         location /backend-api/ {
-            set $upstream_backend_host "java-backend";
-            # NEM vágjuk le az /backend-api/ prefixet!
-            # Helyette az /api/ prefixet adjuk hozzá.
-            # Pl.: /backend-api/data -> http://java-backend:8082/api/data
-#             proxy_pass http://$upstream_backend_host:8082/api/; # <-- Módosítás itt: /api/ a végén
-            proxy_pass http://java-backend:8082/api/;
+            # A "java-backend" név feloldása kérésenként történik, így ha a
+            # konténer később indul el, az Nginx akkor is továbbítja a kéréseket.
+            set $backend_host "java-backend:8082";
+
+            # Az /backend-api/ előtagot /api/‑ra cseréljük le.
+            rewrite ^/backend-api/(.*)$ /api/$1 break;
+
+            proxy_pass http://$backend_host;
 
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- keep nginx running when backend container is absent
- rework `/backend-api/` location to resolve backend host per request
- strip prefix with `rewrite` before proxying

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68429d53b3ac832c8996fbc067dd6d0c