### PR TITLE
Allow nginx startup without backend and add tests

### DIFF
--- a/java-backend/src/test/java/hu/alerant/backend/controller/BackendControllerTest.java
+++ b/java-backend/src/test/java/hu/alerant/backend/controller/BackendControllerTest.java
@@ -1,0 +1,29 @@
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BackendControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void helloEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/hello"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("Hello from Java Backend API!")));
+    }
+
+    @Test
+    void dataEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/data"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("This is some data from the backend.")));
+    }
+}

--- a/java-client/src/test/java/hu/alerant/client/controller/ClientControllerTest.java
+++ b/java-client/src/test/java/hu/alerant/client/controller/ClientControllerTest.java
@@ -1,0 +1,29 @@
+import hu.alerant.client.model.Message;
+import hu.alerant.client.service.ApiService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.when;
+
+@WebFluxTest(ClientController.class)
+class ClientControllerTest {
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private ApiService apiService;
+
+    @Test
+    void callHelloReturnsBackendMessage() {
+        when(apiService.getHelloMessageFromBackend()).thenReturn(Mono.just(new Message("hello")));
+        webTestClient.get().uri("/client/callHello")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.content").isEqualTo("hello");
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,10 @@ http {
     # Nginx DNS feloldás a dinamikus hostokhoz (pl. java-backend)
     resolver 127.0.0.11 valid=10s;
 
+    # A backend kiszolgálót DNS alapon keressük. A "resolver" direktíva miatt
+    # az Nginx újra megkísérli a névfeloldást, így a szolgáltatás későbbi
+    # indítását is kezelni tudjuk.
+
     log_format custom_log '$remote_addr - $remote_user [$time_local] '
                           '"$request" $status $body_bytes_sent '
                           '"$upstream_addr" "$upstream_response_time"';
@@ -29,12 +33,14 @@ http {
 
         # Az útvonal, amit a java-client hív a backend eléréséhez
         location /backend-api/ {
-            set $upstream_backend_host "java-backend";
-            # NEM vágjuk le az /backend-api/ prefixet!
-            # Helyette az /api/ prefixet adjuk hozzá.
-            # Pl.: /backend-api/data -> http://java-backend:8082/api/data
-#             proxy_pass http://$upstream_backend_host:8082/api/; # <-- Módosítás itt: /api/ a végén
-            proxy_pass http://java-backend:8082/api/;
+            # A "java-backend" név feloldása kérésenként történik, így ha a
+            # konténer később indul el, az Nginx akkor is továbbítja a kéréseket.
+            set $backend_host "java-backend:8082";
+
+            # Az /backend-api/ előtagot /api/‑ra cseréljük le.
+            rewrite ^/backend-api/(.*)$ /api/$1 break;
+
+            proxy_pass http://$backend_host;
 
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- allow nginx to resolve the backend host dynamically using a variable and rewrite
- add simple Spring Boot controller tests for backend and client

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `cd java-backend && mvn -q test` *(fails: `mvn: command not found`)*
- `cd java-client && mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68429d53b3ac832c8996fbc067dd6d0c