### PR TITLE
Add client endpoint for backend2 through proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,22 @@ services:
 #      retries: 5
 #      start_period: 30s
 
+#  java-backend2:
+#    build: ./java-backend2
+#    restart: always
+#    ports:
+#      - "8083:8083"
+#    networks:
+#      - app_network
+#    environment:
+#      SERVER_PORT: 8083
+#    healthcheck:
+#      test: ["CMD-SHELL", "curl -f http://localhost:8083/actuator/health || exit 1"]
+#      interval: 10s
+#      timeout: 5s
+#      retries: 5
+#      start_period: 30s
+
 networks:
   app_network:
     driver: bridge

--- a/java-backend/src/test/java/hu/alerant/backend/controller/BackendControllerTest.java
+++ b/java-backend/src/test/java/hu/alerant/backend/controller/BackendControllerTest.java
@@ -1,0 +1,31 @@
+package hu.alerant.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BackendControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void helloEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/hello"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("Hello from Java Backend API!")));
+    }
+
+    @Test
+    void dataEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/data"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("This is some data from the backend.")));
+    }
+}

--- a/java-backend2/Dockerfile
+++ b/java-backend2/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY target/*.jar app.jar
+# A második backend alkalmazás 8083-as porton fut
+EXPOSE 8083
+CMD ["java", "-jar", "app.jar"]

--- a/java-backend2/pom.xml
+++ b/java-backend2/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version> <relativePath/> </parent>
+    <groupId>com.example</groupId>
+    <artifactId>java-backend2</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>java-backend2</name>
+    <description>Demo Spring Boot Backend</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/java-backend2/src/main/java/hu/alerant/backend2/JavaBackend2Application.java
+++ b/java-backend2/src/main/java/hu/alerant/backend2/JavaBackend2Application.java
@@ -1,0 +1,12 @@
+package hu.alerant.backend2;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class JavaBackend2Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(JavaBackend2Application.class, args);
+    }
+}

--- a/java-backend2/src/main/java/hu/alerant/backend2/controller/Backend2Controller.java
+++ b/java-backend2/src/main/java/hu/alerant/backend2/controller/Backend2Controller.java
@@ -1,0 +1,26 @@
+package hu.alerant.backend2.controller;
+
+
+import hu.alerant.backend2.model.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@Slf4j
+public class Backend2Controller {
+
+    @GetMapping("/hello")
+    public Message getHelloMessage() {
+        log.info("backend2 hello call");
+        return new Message("Hello from Java Backend2 API!");
+    }
+
+    @GetMapping("/data")
+    public Message getData() {
+        log.info("backend2 data call");
+        return new Message("This is some data from the backend2.");
+    }
+}

--- a/java-backend2/src/main/java/hu/alerant/backend2/model/Message.java
+++ b/java-backend2/src/main/java/hu/alerant/backend2/model/Message.java
@@ -1,0 +1,14 @@
+package hu.alerant.backend2.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter@Setter
+public class Message {
+    private String content;
+}

--- a/java-backend2/src/main/resources/application.properties
+++ b/java-backend2/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+management.endpoints.web.exposure.include=health
+server.port=8083

--- a/java-backend2/src/test/java/hu/alerant/backend2/controller/Backend2ControllerTest.java
+++ b/java-backend2/src/test/java/hu/alerant/backend2/controller/Backend2ControllerTest.java
@@ -1,0 +1,31 @@
+package hu.alerant.backend2.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.is;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class Backend2ControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void helloEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/hello"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("Hello from Java Backend2 API!")));
+    }
+
+    @Test
+    void dataEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/api/data"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", is("This is some data from the backend2.")));
+    }
+}

--- a/java-client/src/main/java/hu/alerant/client/controller/ClientController.java
+++ b/java-client/src/main/java/hu/alerant/client/controller/ClientController.java
@@ -29,4 +29,10 @@ public class ClientController {
         return apiService.getDataFromBackend()
                 .onErrorReturn(new Message("Backend Data Service is currently unavailable.")); // <-- Hiba esetén fallback üzenet
     }
+
+    @GetMapping("/callBackend2Hello")
+    public Mono<Message> callBackend2Hello() {
+        return apiService.getHelloMessageFromBackend2()
+                .onErrorReturn(new Message("Backend2 Hello Service is currently unavailable."));
+    }
 }

--- a/java-client/src/main/java/hu/alerant/client/service/ApiService.java
+++ b/java-client/src/main/java/hu/alerant/client/service/ApiService.java
@@ -85,4 +85,8 @@ public class ApiService {
     public Mono<Message> getDataFromBackend() {
         return makeRequest("/backend-api/data", Message.class); // Útvonal az Nginx-hez
     }
+
+    public Mono<Message> getHelloMessageFromBackend2() {
+        return makeRequest("/backend2-api/hello", Message.class);
+    }
 }

--- a/java-client/src/test/java/hu/alerant/client/controller/ClientControllerTest.java
+++ b/java-client/src/test/java/hu/alerant/client/controller/ClientControllerTest.java
@@ -1,0 +1,41 @@
+package hu.alerant.client.controller;
+
+import hu.alerant.client.model.Message;
+import hu.alerant.client.service.ApiService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.when;
+
+@WebFluxTest(ClientController.class)
+class ClientControllerTest {
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private ApiService apiService;
+
+    @Test
+    void callHelloReturnsBackendMessage() {
+        when(apiService.getHelloMessageFromBackend()).thenReturn(Mono.just(new Message("hello")));
+        webTestClient.get().uri("/client/callHello")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.content").isEqualTo("hello");
+    }
+
+    @Test
+    void callBackend2HelloReturnsMessage() {
+        when(apiService.getHelloMessageFromBackend2()).thenReturn(Mono.just(new Message("hello2")));
+        webTestClient.get().uri("/client/callBackend2Hello")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.content").isEqualTo("hello2");
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,6 +13,10 @@ http {
     # Nginx DNS feloldás a dinamikus hostokhoz (pl. java-backend)
     resolver 127.0.0.11 valid=10s;
 
+    # A backend kiszolgálót DNS alapon keressük. A "resolver" direktíva miatt
+    # az Nginx újra megkísérli a névfeloldást, így a szolgáltatás későbbi
+    # indítását is kezelni tudjuk.
+
     log_format custom_log '$remote_addr - $remote_user [$time_local] '
                           '"$request" $status $body_bytes_sent '
                           '"$upstream_addr" "$upstream_response_time"';
@@ -29,12 +33,29 @@ http {
 
         # Az útvonal, amit a java-client hív a backend eléréséhez
         location /backend-api/ {
-            set $upstream_backend_host "java-backend";
-            # NEM vágjuk le az /backend-api/ prefixet!
-            # Helyette az /api/ prefixet adjuk hozzá.
-            # Pl.: /backend-api/data -> http://java-backend:8082/api/data
-#             proxy_pass http://$upstream_backend_host:8082/api/; # <-- Módosítás itt: /api/ a végén
-            proxy_pass http://java-backend:8082/api/;
+            # A "java-backend" név feloldása kérésenként történik, így ha a
+            # konténer később indul el, az Nginx akkor is továbbítja a kéréseket.
+            set $backend_host "java-backend:8082";
+
+            # Az /backend-api/ előtagot /api/‑ra cseréljük le.
+            rewrite ^/backend-api/(.*)$ /api/$1 break;
+
+            proxy_pass http://$backend_host;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            access_log /var/log/nginx/internal_backend_proxy_access.log custom_log;
+            error_log /var/log/nginx/internal_backend_proxy_error.log error;
+        }
+
+        # Második backend alkalmazás
+        location /backend2-api/ {
+            set $backend2_host "java-backend2:8083";
+            rewrite ^/backend2-api/(.*)$ /api/$1 break;
+            proxy_pass http://$backend2_host;
 
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- add `/client/callBackend2Hello` endpoint in `ClientController`
- implement corresponding service call to `/backend2-api/hello`
- test new endpoint in `ClientControllerTest`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)
- `cd java-client && mvn -q test && tail -n 20 /tmp/mvn_client.log` *(fails: `mvn: command not found`)
- `cd java-backend && mvn -q test && tail -n 20 /tmp/mvn_backend.log` *(fails: `mvn: command not found`)
- `cd java-backend2 && mvn -q test && tail -n 20 /tmp/mvn_backend2.log` *(fails: `mvn: command not found`)


------
https://chatgpt.com/codex/tasks/task_b_68429d53b3ac832c8996fbc067dd6d0c