### PR TITLE
Fix nginx module version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # API Gateway
 
-This repository contains a small demo with Nginx acting as a reverse proxy for multiple backend applications. The gateway uses a custom Nginx image built from the official `nginx:alpine` base with the Lua module installed.
+This repository contains a small demo with Nginx acting as a reverse proxy for multiple backend applications. The gateway uses a custom Nginx image built from the official `nginx:1.26.3-alpine` base with the Lua module installed. Pinning the Nginx version prevents module version mismatches.
 
 ## Log configuration
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:alpine
+FROM nginx:1.26.3-alpine
 RUN apk add --no-cache nginx-mod-http-lua lua-resty-core lua-resty-lrucache


### PR DESCRIPTION
## Summary
- pin base image to nginx 1.26.3
- update README accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6848155f65f8832c94015f733adaebcf