### PR TITLE
Fix Nginx config path and update test script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,11 @@ services:
     image: openresty/openresty:alpine
     # NINCS port mapping kívülre! Csak a belső hálózaton keresztül érhető el.
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/log_format.conf:/etc/nginx/log_format.conf:ro
-      - ./nginx/app_logger.lua:/etc/nginx/app_logger.lua:ro
-      - ./nginx/app_logger_body.lua:/etc/nginx/app_logger_body.lua:ro
+      # Mount the configuration directly into OpenResty's default path
+      - ./nginx/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
+      - ./nginx/log_format.conf:/usr/local/openresty/nginx/conf/log_format.conf:ro
+      - ./nginx/app_logger.lua:/usr/local/openresty/nginx/conf/app_logger.lua:ro
+      - ./nginx/app_logger_body.lua:/usr/local/openresty/nginx/conf/app_logger_body.lua:ro
       - ./nginx/logs:/var/log/nginx
     networks:
       - app_network

--- a/test-script.ps1
+++ b/test-script.ps1
@@ -12,9 +12,8 @@ foreach ($c in $containers) {
     }
 }
 
-# Build nginx image without using cache and start the proxy
-Write-Host "Building nginx image..."
-docker compose build --no-cache nginx
+# Start the nginx proxy (configuration is mounted into
+# /usr/local/openresty/nginx/conf by docker-compose)
 Write-Host "Starting nginx proxy with docker-compose..."
 docker compose up -d nginx
 


### PR DESCRIPTION
## Summary
- mount nginx config files to OpenResty's default path so the custom routing works
- simplify PowerShell test script and note the config path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684831fdf448832c83685cc079262aa8