### PR TITLE
Implement configurable JSON logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,15 @@ to regenerate `nginx/log_format.conf`. The `docker-compose` setup mounts this ge
 
 Nginx also writes an `application.log` file that contains the full request and response (headers and body) using Lua scripts. The log is located under `nginx/logs/` inside the container.
 
+### Application log options
+
+The behaviour of `application.log` can be tuned through environment variables used by
+the Lua logger:
+
+* `APP_LOG_INCLUDE_HEADERS` – set to `false` to omit request/response headers.
+* `APP_LOG_INCLUDE_BODY` – set to `false` to omit request/response bodies.
+* `APP_LOG_HEADER_PARAM` – if set, logs the value of the named request header under `header_param`.
+
+All options default to logging everything.
+
 The Nginx image is built from the `nginx/Dockerfile`. Run `docker-compose build nginx` whenever the configuration or Lua scripts change.

--- a/nginx/app_logger.lua
+++ b/nginx/app_logger.lua
@@ -1,27 +1,54 @@
 local cjson = require "cjson.safe"
 
-local req_body = ngx.var.request_body or ""
-local req_headers = ngx.req.get_headers()
-local resp_headers = ngx.resp.get_headers()
-local resp_body = ngx.ctx.resp_body or ""
-
-local log_entry = {
-  request = {
-    method = ngx.req.get_method(),
-    uri = ngx.var.request_uri,
-    headers = req_headers,
-    body = req_body
-  },
-  response = {
-    status = ngx.status,
-    headers = resp_headers,
-    body = resp_body
-  }
-}
-
-local f, err = io.open("/var/log/nginx/application.log", "a")
-if f then
-  f:write(cjson.encode(log_entry), "\n")
-  f:close()
+-- configuration flags (defaults to true)
+local include_headers = true
+local h_env = os.getenv("APP_LOG_INCLUDE_HEADERS")
+if h_env and h_env:lower() == "false" then
+  include_headers = false
 end
 
+local include_body = true
+local b_env = os.getenv("APP_LOG_INCLUDE_BODY")
+if b_env and b_env:lower() == "false" then
+  include_body = false
+end
+
+local header_param_name = os.getenv("APP_LOG_HEADER_PARAM")
+
+-- collect request/response data based on flags
+local req_headers = include_headers and ngx.req.get_headers() or nil
+local req_body = include_body and (ngx.var.request_body or "") or nil
+local resp_headers = include_headers and ngx.resp.get_headers() or nil
+local resp_body = include_body and (ngx.ctx.resp_body or "") or nil
+
+local header_param_value
+if header_param_name and req_headers then
+  header_param_value = req_headers[header_param_name]
+end
+
+local request_tbl = {
+  method = ngx.req.get_method(),
+  uri = ngx.var.request_uri
+}
+if req_headers then request_tbl.headers = req_headers end
+if req_body ~= nil then request_tbl.body = req_body end
+if header_param_value then request_tbl.header_param = header_param_value end
+
+local response_tbl = {}
+if resp_headers then response_tbl.headers = resp_headers end
+if resp_body ~= nil then response_tbl.body = resp_body end
+
+-- build JSON string manually to keep key order
+local parts = {}
+parts[#parts+1] = '"timestamp":' .. cjson.encode(os.date("!%Y-%m-%dT%H:%M:%SZ"))
+parts[#parts+1] = '"request":' .. cjson.encode(request_tbl)
+parts[#parts+1] = '"response":' .. cjson.encode(response_tbl)
+parts[#parts+1] = '"status":' .. tostring(ngx.status)
+
+local log_line = "{" .. table.concat(parts, ",") .. "}\n"
+
+local f = io.open("/var/log/nginx/application.log", "a")
+if f then
+  f:write(log_line)
+  f:close()
+end

--- a/nginx/app_logger.lua
+++ b/nginx/app_logger.lua
@@ -15,7 +15,6 @@ end
 
 local header_param_name = os.getenv("APP_LOG_HEADER_PARAM")
 
--- collect request/response data based on flags
 local req_headers = include_headers and ngx.req.get_headers() or nil
 local req_body = include_body and (ngx.var.request_body or "") or nil
 local resp_headers = include_headers and ngx.resp.get_headers() or nil
@@ -26,23 +25,25 @@ if header_param_name and req_headers then
   header_param_value = req_headers[header_param_name]
 end
 
-local request_tbl = {
-  method = ngx.req.get_method(),
-  uri = ngx.var.request_uri
-}
-if req_headers then request_tbl.headers = req_headers end
-if req_body ~= nil then request_tbl.body = req_body end
-if header_param_value then request_tbl.header_param = header_param_value end
+-- build request JSON manually so headers come before body
+local req_parts = {}
+if req_headers then req_parts[#req_parts+1] = '"headers":' .. cjson.encode(req_headers) end
+req_parts[#req_parts+1] = '"method":' .. cjson.encode(ngx.req.get_method())
+req_parts[#req_parts+1] = '"uri":' .. cjson.encode(ngx.var.request_uri)
+if req_body ~= nil then req_parts[#req_parts+1] = '"body":' .. cjson.encode(req_body) end
+if header_param_value then req_parts[#req_parts+1] = '"header_param":' .. cjson.encode(header_param_value) end
+local request_json = '{' .. table.concat(req_parts, ',') .. '}'
 
-local response_tbl = {}
-if resp_headers then response_tbl.headers = resp_headers end
-if resp_body ~= nil then response_tbl.body = resp_body end
+local resp_parts = {}
+if resp_headers then resp_parts[#resp_parts+1] = '"headers":' .. cjson.encode(resp_headers) end
+if resp_body ~= nil then resp_parts[#resp_parts+1] = '"body":' .. cjson.encode(resp_body) end
+local response_json = '{' .. table.concat(resp_parts, ',') .. '}'
 
 -- build JSON string manually to keep key order
 local parts = {}
 parts[#parts+1] = '"timestamp":' .. cjson.encode(os.date("!%Y-%m-%dT%H:%M:%SZ"))
-parts[#parts+1] = '"request":' .. cjson.encode(request_tbl)
-parts[#parts+1] = '"response":' .. cjson.encode(response_tbl)
+parts[#parts+1] = '"request":' .. request_json
+parts[#parts+1] = '"response":' .. response_json
 parts[#parts+1] = '"status":' .. tostring(ngx.status)
 
 local log_line = "{" .. table.concat(parts, ",") .. "}\n"

--- a/nginx/app_logger_body.lua
+++ b/nginx/app_logger_body.lua
@@ -1,8 +1,11 @@
-if ngx.ctx.resp_body then
-  ngx.ctx.resp_body = ngx.ctx.resp_body .. (ngx.arg[1] or "")
-else
-  ngx.ctx.resp_body = ngx.arg[1] or ""
-end
-if ngx.arg[2] then
-  -- end of body
+local include_body = os.getenv("APP_LOG_INCLUDE_BODY")
+if include_body == nil or include_body:lower() ~= "false" then
+  if ngx.ctx.resp_body then
+    ngx.ctx.resp_body = ngx.ctx.resp_body .. (ngx.arg[1] or "")
+  else
+    ngx.ctx.resp_body = ngx.arg[1] or ""
+  end
+  if ngx.arg[2] then
+    -- end of body
+  end
 end

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,6 +2,9 @@
 #load_module modules/ngx_http_lua_module.so;
 
 worker_processes 1;
+env APP_LOG_INCLUDE_HEADERS;
+env APP_LOG_INCLUDE_BODY;
+env APP_LOG_HEADER_PARAM;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
## Summary
- make request/response logging format configurable
- add environment variables to control log output
- document application log options
- fix the application.log field order

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68484eab7a24832cb5697b647a21cac3