### PR TITLE
Support response header logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ the Lua logger:
 
 * `APP_LOG_INCLUDE_HEADERS` – set to `false` to omit request/response headers.
 * `APP_LOG_INCLUDE_BODY` – set to `false` to omit request/response bodies.
-* `APP_LOG_HEADER_PARAM` – if set, logs the value of the named request header under `header_param`.
+* `APP_LOG_HEADER_PARAM` – comma-separated list of header names to log under
+  `header_param` in both the request and response sections even when
+  `APP_LOG_INCLUDE_HEADERS` is `false`.
 
 All options default to logging everything.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   nginx:
     image: openresty/openresty:alpine
     environment:
-      APP_LOG_INCLUDE_HEADERS: "true"
+      APP_LOG_INCLUDE_HEADERS: "false"
       APP_LOG_INCLUDE_BODY: "false"
-      APP_LOG_HEADER_PARAM: "x-app-header"
+      APP_LOG_HEADER_PARAM: "x-app-header,x-demo-header"
     volumes:
       # Mount the configuration directly into OpenResty's default path
       - ./nginx/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro

--- a/nginx/app_logger.lua
+++ b/nginx/app_logger.lua
@@ -13,16 +13,35 @@ if b_env and b_env:lower() == "false" then
   include_body = false
 end
 
-local header_param_name = os.getenv("APP_LOG_HEADER_PARAM")
+local header_param_env = os.getenv("APP_LOG_HEADER_PARAM")
+local header_param_names = {}
+if header_param_env then
+  for name in string.gmatch(header_param_env, "[^,%s]+") do
+    header_param_names[#header_param_names + 1] = name
+  end
+end
 
 local req_headers = include_headers and ngx.req.get_headers() or nil
 local req_body = include_body and (ngx.var.request_body or "") or nil
 local resp_headers = include_headers and ngx.resp.get_headers() or nil
 local resp_body = include_body and (ngx.ctx.resp_body or "") or nil
 
-local header_param_value
-if header_param_name and req_headers then
-  header_param_value = req_headers[header_param_name]
+local function extract_headers(names, source)
+  if #names == 1 then
+    return source[names[1]]
+  end
+  local out = {}
+  for _, n in ipairs(names) do
+    out[n] = source[n]
+  end
+  return out
+end
+
+local header_param_req
+local header_param_resp
+if #header_param_names > 0 then
+  header_param_req = extract_headers(header_param_names, req_headers or ngx.req.get_headers())
+  header_param_resp = extract_headers(header_param_names, resp_headers or ngx.resp.get_headers())
 end
 
 -- build request JSON manually so headers come before body
@@ -31,12 +50,13 @@ if req_headers then req_parts[#req_parts+1] = '"headers":' .. cjson.encode(req_h
 req_parts[#req_parts+1] = '"method":' .. cjson.encode(ngx.req.get_method())
 req_parts[#req_parts+1] = '"uri":' .. cjson.encode(ngx.var.request_uri)
 if req_body ~= nil then req_parts[#req_parts+1] = '"body":' .. cjson.encode(req_body) end
-if header_param_value then req_parts[#req_parts+1] = '"header_param":' .. cjson.encode(header_param_value) end
+if header_param_req then req_parts[#req_parts+1] = '"header_param":' .. cjson.encode(header_param_req) end
 local request_json = '{' .. table.concat(req_parts, ',') .. '}'
 
 local resp_parts = {}
 if resp_headers then resp_parts[#resp_parts+1] = '"headers":' .. cjson.encode(resp_headers) end
 if resp_body ~= nil then resp_parts[#resp_parts+1] = '"body":' .. cjson.encode(resp_body) end
+if header_param_resp then resp_parts[#resp_parts+1] = '"header_param":' .. cjson.encode(header_param_resp) end
 local response_json = '{' .. table.concat(resp_parts, ',') .. '}'
 
 -- build JSON string manually to keep key order


### PR DESCRIPTION
## Summary
- document that APP_LOG_HEADER_PARAM logs headers from request and response
- log selected headers from responses as well as requests

## Testing
- `lua -v` *(fails: command not found)*
- `mvn -v` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6849473caab8832c989de0b2a0e35de3