### PR TITLE
Fix configAPI routing

### DIFF
--- a/nginx/routes.conf
+++ b/nginx/routes.conf
@@ -13,7 +13,9 @@ location /backend-api/ {
 # configAPI route
 location /api/configAPI {
     set $configAPI_host "dxl-client-config-svc:8080";
-    rewrite ^/api/configAPI(.*)$ /api/configAPI/$1 break;
+    # Preserve the exact path without appending a trailing slash
+    # so Spring Boot mappings without trailing slash are matched
+    rewrite ^/api/configAPI(.*)$ /api/configAPI$1 break;
     proxy_pass http://$configAPI_host;
 }
 


### PR DESCRIPTION
## Summary
- fix configAPI route to avoid trailing slash

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a8dfe0770832cb7ddf9902410ce31