### PR TITLE
Add startup log for env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN mkdir -p /var/log/nginx
 
 EXPOSE 80
 
-CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The provided `docker-compose.yml` loads these variables from `.env.dev` and
 passes them to the Nginx container. Adjust the values in that file to control
 what the Lua logger records.
 
+The Docker image prints the current values of these variables to the container
+log on startup via a small entrypoint script. This helps verify that the
+expected settings are in effect.
+
 
 ## Route configuration
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "APP_LOG_INCLUDE_HEADERS=${APP_LOG_INCLUDE_HEADERS}"
+echo "APP_LOG_INCLUDE_BODY=${APP_LOG_INCLUDE_BODY}"
+echo "APP_LOG_HEADER_PARAM=${APP_LOG_HEADER_PARAM}"
+
+exec /usr/local/openresty/bin/openresty -g 'daemon off;'


### PR DESCRIPTION
## Summary
- add an entrypoint to print logging-related env vars
- update Dockerfile to use the entrypoint
- document that env vars are printed when the container starts

## Testing
- `bash -n entrypoint.sh`
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68761ac810d0832c80d8fb94119556f5