### PR TITLE
Print logging flags on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ COPY nginx/app_logger.lua /usr/local/openresty/nginx/conf/app_logger.lua
 COPY nginx/app_logger_body.lua /usr/local/openresty/nginx/conf/app_logger_body.lua
 COPY nginx/routes.conf /usr/local/openresty/nginx/route/routes.conf
 
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 RUN mkdir -p /var/log/nginx
 
 EXPOSE 80
-
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ The provided `docker-compose.yml` loads these variables from `.env.dev` and
 passes them to the Nginx container. Adjust the values in that file to control
 what the Lua logger records.
 
+When using the PowerShell script `test-script-dockerfile.ps1` the container is
+started directly with `docker run`. In this case the environment file is passed
+explicitly so the logging variables take effect. The entrypoint of the image now
+prints the current values of these variables when the container starts which
+helps verifying that the correct configuration is applied.
+
 
 ## Route configuration
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Print important logging flags for visibility when the container starts
+echo "APP_LOG_INCLUDE_HEADERS=$APP_LOG_INCLUDE_HEADERS"
+echo "APP_LOG_INCLUDE_BODY=$APP_LOG_INCLUDE_BODY"
+echo "APP_LOG_HEADER_PARAM=$APP_LOG_HEADER_PARAM"
+exec "$@"

--- a/test-script-dockerfile.ps1
+++ b/test-script-dockerfile.ps1
@@ -21,7 +21,10 @@ Write-Host "Starting nginx proxy with docker file..."
 $networkName = "api-gw_app_network"
 docker network create api-gw_app_network
 docker build -t api-gw:latest .
-docker run -d --name nginx --network $networkName api-gw:latest
+Write-Host "Using environment variables from .env.dev"
+Get-Content .env.dev
+$envFile = "./.env.dev"
+docker run -d --name nginx --network $networkName --env-file $envFile api-gw:latest
 
 # Wait a few seconds for nginx to be ready
 Start-Sleep -Seconds 5


### PR DESCRIPTION
## Summary
- show environment flags while nginx starts
- add entrypoint script printing the logging flag values
- use env file in PowerShell test script
- document the behaviour in README

## Testing
- `sh -n docker-entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_b_687609b14698832c8f755c9141a21c06