### PR TITLE
Handle duplicate upstream headers in API gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY nginx/log_format.conf /usr/local/openresty/nginx/conf/log_format.conf
 COPY nginx/app_logger.lua /usr/local/openresty/nginx/conf/app_logger.lua
 COPY nginx/app_logger_body.lua /usr/local/openresty/nginx/conf/app_logger_body.lua
 COPY nginx/routes.conf /usr/local/openresty/nginx/route/routes.conf
+COPY nginx/duplicate_header_proxy.lua /usr/local/openresty/nginx/conf/duplicate_header_proxy.lua
 
 RUN mkdir -p /var/log/nginx
 

--- a/nginx/duplicate_header_proxy.lua
+++ b/nginx/duplicate_header_proxy.lua
@@ -1,0 +1,30 @@
+-- Proxy request to upstream while tolerating duplicate headers
+local http = require "resty.http"
+
+local upstream = "http://host.docker.internal:58084"
+
+local httpc = http.new()
+local res, err = httpc:request_uri(upstream .. ngx.var.request_uri, {
+    method = ngx.req.get_method(),
+    headers = ngx.req.get_headers(),
+    body = ngx.req.get_body_data(),
+})
+
+if not res then
+    ngx.log(ngx.ERR, "failed to request upstream: ", err)
+    return ngx.exit(502)
+end
+
+ngx.status = res.status
+for k, v in pairs(res.headers) do
+    if k:lower() == "transfer-encoding" then
+        -- ignore duplicate Transfer-Encoding headers by setting only once
+        if not ngx.header[k] then
+            ngx.header[k] = v
+        end
+    else
+        ngx.header[k] = v
+    end
+end
+ngx.print(res.body or "")
+

--- a/nginx/routes.conf
+++ b/nginx/routes.conf
@@ -149,12 +149,8 @@ location /tmf-api/privacyManagement {
 }
 
 location /tmf-api/partyRoleManagement {
-    set $partyRoleAPI_nc_host "host.docker.internal:58084";
-    proxy_http_version 1.1;
-    chunked_transfer_encoding off;
-    proxy_set_header Host localhost:58084;   # same Host header as direct call
-    proxy_set_header Connection "";          # avoid sending "Connection: close"
-    proxy_pass http://$partyRoleAPI_nc_host;
+    # Use a Lua-based proxy to tolerate duplicate headers from the upstream
+    content_by_lua_file /usr/local/openresty/nginx/conf/duplicate_header_proxy.lua;
 }
 # partyRoleAPI-nc route
 # location /tmf-api/partyRoleManagement {


### PR DESCRIPTION
## Summary
- add Lua script to proxy requests while ignoring duplicate headers
- update OpenResty config to use the Lua-based proxy for the `partyRoleManagement` route
- include new script in Docker image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687f5d0ba028832c9d182e488e8e77de